### PR TITLE
add function is_us_day_of_month()

### DIFF
--- a/top_runner_util.py
+++ b/top_runner_util.py
@@ -133,13 +133,11 @@ def run_custom_date(script_folder_name, script_name, date_list):
 #     return result
 def is_US_day_of_month(day_number, date=_TODAY):
     """Return True for US day of month. If that day is a holiday, return True the next day
-
-    Note: The next day doesn't row over to next month.
-        ie. If you check for May 31st and it's a holiday, you won't get True for June 1
     """
     # if yesterday was a holiday, and today is not
-    if is_day_of_month(date, day_number+1, check_holiday=True, country='US') and \
-        (not is_not_holiday(date-timedelta(days=1),'US')):
+    yesterday = date-timedelta(days=1)
+    if is_day_of_month(yesterday, day_number) and (not is_not_holiday(yesterday,'US')):
+        log_info("Yesterday was holiday, running today.")
         return True
     else:
         return is_day_of_month(date, day_number, check_holiday=True, country='US')
@@ -197,8 +195,8 @@ def test():
 
     # ----------- Test is_US_day_of_month()---------
     print("-------Test is_US_day_of_month ----------")
-    date_list = [datetime.strptime('2021-07-01', "%Y-%m-%d")+timedelta(days=x) for x in range(8)]
+    date_list = [datetime.strptime('2021-05-25', "%Y-%m-%d")+timedelta(days=x) for x in range(8)]
     for d in date_list:
-        print(d.strftime("%Y-%m-%d"), "is day 5 of month", is_US_day_of_month(5, d))
+        print(d.strftime("%Y-%m-%d"), "is day 31 of month", is_US_day_of_month(31, d))
 if __name__ == "__main__":
     test()

--- a/top_runner_util.py
+++ b/top_runner_util.py
@@ -131,6 +131,18 @@ def run_custom_date(script_folder_name, script_name, date_list):
 #     dd = datetime.today()
 #     result = ( (dd.weekday() == 5) or  (dd.weekday() == 6) )
 #     return result
+def is_US_day_of_month(day_number, date=_TODAY):
+    """Return True for US day of month. If that day is a holiday, return True the next day
+
+    Note: The next day doesn't row over to next month.
+        ie. If you check for May 31st and it's a holiday, you won't get True for June 1
+    """
+    # if yesterday was a holiday, and today is not
+    if is_day_of_month(date, day_number+1, check_holiday=True, country='US') and \
+        (not is_not_holiday(date-timedelta(days=1),'US')):
+        return True
+    else:
+        return is_day_of_month(date, day_number, check_holiday=True, country='US')
 
 def isToday_Saturday():
     dd = datetime.today()
@@ -182,5 +194,11 @@ def test():
     date_list = [_TODAY - timedelta(days=x) for x in range(8)]
     for d in date_list:
         print(d.strftime("%Y-%m-%d"), "day of the week:", d.weekday(), is_COMEX_thursday_run(d))
+
+    # ----------- Test is_US_day_of_month()---------
+    print("-------Test is_US_day_of_month ----------")
+    date_list = [datetime.strptime('2021-07-01', "%Y-%m-%d")+timedelta(days=x) for x in range(8)]
+    for d in date_list:
+        print(d.strftime("%Y-%m-%d"), "is day 5 of month", is_US_day_of_month(5, d))
 if __name__ == "__main__":
     test()


### PR DESCRIPTION
Added a function to check if today is US day of month. If this day is a holiday, it will return false, and the next day will return True. However, the next day does not row over to next month. So if May 31 is a holiday, you won't get a True on June 1st. 

* How to use it. Example: checking if today is 5th of every month. 
```python
is_US_day_of_month(5)
```

* Test result. Test code in test() function. Testing for 5th of every month. Input: July 1 to July 8, where 2021 July 5 is holiday (Independence day)
```
-------Test is_US_day_of_month ----------
2021-07-01 is day 5 of month False
2021-07-02 is day 5 of month False
2021-07-03 is day 5 of month False
2021-07-04 is day 5 of month False
2021-07-05 is day 5 of month False
2021-07-06 is day 5 of month True
2021-07-07 is day 5 of month False
2021-07-08 is day 5 of month False
```

